### PR TITLE
Add method to skip alignment for exact overlaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ include(ExternalProject)
 # Download or update library as an external project
 ExternalProject_Add(project_spoa
         GIT_REPOSITORY https://github.com/rvaser/spoa.git
-        GIT_SUBMODULES vendor/bioparser vendor/cereal vendor/cpu_features vendor/simde
+#        GIT_SUBMODULES vendor/bioparser vendor/cereal vendor/cpu_features vendor/simde
 #        DOWNLOAD_COMMAND ""
 #        UPDATE_COMMAND ""
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/

--- a/inc/Bluntifier.hpp
+++ b/inc/Bluntifier.hpp
@@ -100,6 +100,10 @@ private:
 
     void align_biclique_overlaps(size_t i);
 
+    bool biclique_overlaps_are_exact(size_t i);
+
+    void create_exact_subgraph(size_t i);
+
     void add_alignments_to_poa(
             Graph& spoa_graph,
             unique_ptr<AlignmentEngine>& alignment_engine,

--- a/src/Bluntifier.cpp
+++ b/src/Bluntifier.cpp
@@ -515,7 +515,7 @@ void Bluntifier::bluntify(){
     log_progress("Reading GFA...");
 
     gfa_to_handle_graph(gfa_path, gfa_graph, id_map, overlaps);
-    
+
     log_progress("Computing adjacency components...");
 
     // Compute Adjacency Components and store in vector

--- a/src/executable/get_blunted.cpp
+++ b/src/executable/get_blunted.cpp
@@ -9,6 +9,7 @@ using std::cerr;
 using std::cout;
 using std::endl;
 
+
 void print_usage() {
     cerr << "usage: get_blunted [options] overlap_graph.gfa > blunt_graph.gfa" << endl;
     cerr << endl;


### PR DESCRIPTION
Don't compute alignments using POA when a biclique subgraph contains only trivial overlaps of the same size