### PR TITLE
Make sure that M operations are real before skipping alignment

### DIFF
--- a/inc/Cigar.hpp
+++ b/inc/Cigar.hpp
@@ -89,7 +89,7 @@ public:
     bool step_through_alignment(AlignmentIterator& iterator);
 
     // Use the ref and query sequences to find mismatches and convert all M operations to = or X
-    void explicitize_mismatches(
+    vector<Cigar> explicitize_mismatches(
             const string& ref_sequence,
             const string& query_sequence,
             uint64_t ref_start_index = 0,
@@ -97,7 +97,7 @@ public:
 
     // Use the ref and query sequences to find mismatches and convert all M operations to = or X
     // Access the handlegraph sequences directly instead of expecting a string
-    void explicitize_mismatches(
+    vector<Cigar> explicitize_mismatches(
             const HandleGraph& graph,
             const edge_t& edge,
             uint64_t ref_start_index = 0,

--- a/src/BluntifierAlign.cpp
+++ b/src/BluntifierAlign.cpp
@@ -167,7 +167,16 @@ bool Bluntifier::biclique_overlaps_are_exact(size_t i){
            break;
         }
         else{
-            sizes.emplace(alignment.operations[0].length);
+            auto ref_start = gfa_graph.get_length(edge.first) - alignment.operations[0].length;
+            auto query_start = 0;
+            auto explicit_cigar_operations = alignment.explicitize_mismatches(gfa_graph, edge, ref_start, query_start);
+
+            sizes.emplace(explicit_cigar_operations[0].length);
+
+            if (not (explicit_cigar_operations.size() == 1 and explicit_cigar_operations[0].type() == '=')){
+                exact = false;
+                break;
+            }
         }
     }
 

--- a/src/Cigar.cpp
+++ b/src/Cigar.cpp
@@ -191,11 +191,11 @@ bool Alignment::step_through_alignment(AlignmentIterator& iterator){
 }
 
 
-void Alignment::explicitize_mismatches(
+vector<Cigar> Alignment::explicitize_mismatches(
         const string& query_sequence,
         const string& ref_sequence,
-        uint64_t query_start_index,
-        uint64_t ref_start_index) {
+        uint64_t ref_start_index,
+        uint64_t query_start_index){
 
     // TODO: rewrite this function without copying? Use insert operations instead
 
@@ -237,15 +237,15 @@ void Alignment::explicitize_mismatches(
         }
     }
 
-    operations = explicit_operations;
+    return explicit_operations;
 }
 
 
-void Alignment::explicitize_mismatches(
+vector<Cigar> Alignment::explicitize_mismatches(
         const HandleGraph& graph,
         const edge_t& edge,
-        uint64_t query_start_index,
-        uint64_t ref_start_index) {
+        uint64_t ref_start_index,
+        uint64_t query_start_index) {
 
     // TODO: rewrite this function without copying? Use insert operations instead
 
@@ -287,7 +287,7 @@ void Alignment::explicitize_mismatches(
         }
     }
 
-    operations = explicit_operations;
+    return explicit_operations;
 }
 
 

--- a/src/test/test_cigar.cpp
+++ b/src/test/test_cigar.cpp
@@ -167,17 +167,17 @@ int main(){
 
     Alignment non_explicit(mismatch_vs_ref);
     cerr << non_explicit << '\n';
-    non_explicit.explicitize_mismatches(ref, mismatch);
+    auto explicit_operations = non_explicit.explicitize_mismatches(ref, mismatch);
     cerr << non_explicit << '\n';
 
     for (size_t i=0; i<cigar_mismatch_vs_ref_explicit.size(); i++){
-        if (i>non_explicit.operations.size()){
+        if (i>explicit_operations.size()){
             throw runtime_error("FAIL: explitized matches don't agree with truth set");
         }
-        if (non_explicit.operations[i].code != cigar_mismatch_vs_ref_explicit[i].code){
+        if (explicit_operations[i].code != cigar_mismatch_vs_ref_explicit[i].code){
             throw runtime_error("FAIL: explitized matches don't agree with truth set");
         }
-        if (non_explicit.operations[i].length != cigar_mismatch_vs_ref_explicit[i].length){
+        if (explicit_operations[i].length != cigar_mismatch_vs_ref_explicit[i].length){
             throw runtime_error("FAIL: explitized matches don't agree with truth set");
         }
     }


### PR DESCRIPTION
A bug was introduced when adding an alternate method for alignment that skips exact overlaps. As it turns out the word "Match" doesn't really mean anything to bioinformaticians, and cigar matches need to be explicitly checked to see if they are actually mismatches