### PR TITLE
Fix overlapping overlaps occuring on one side only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ------- Memory debug ------- #
 
+# No ASan for static builds :'(
 #set(CMAKE_CXX_FLAGS "-fexceptions -fsanitize=address")
 #set(ASAN_OPTIONS=check_initialization_order=1)
 #set(ASAN_OPTIONS=detect_leaks=1)
@@ -27,8 +28,12 @@ set(CMAKE_CXX_FLAGS "-fexceptions")
 
 # ---------------------------- #
 
-#add_definitions(-ggdb3 -O0 -Wall)       # Debugging + No optimization
-add_definitions(-O3 -Wall)              # Much optimization
+if(dev)
+    message(STATUS "--- Using dev build options ---")
+    add_definitions(-ggdb3 -O0 -Wall)       # Debugging + No optimization
+else()
+    add_definitions(-O3 -Wall)              # Much optimization
+endif()
 
 #########################################
 # ------------------------------------- #
@@ -152,17 +157,29 @@ endif()
 # Need to explicitly enable ExternalProject functionality
 include(ExternalProject)
 
-# Download or update library as an external project
-ExternalProject_Add(project_gfak
-        GIT_REPOSITORY https://github.com/edawson/gfakluge.git
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-        CONFIGURE_COMMAND ""
-#	    DOWNLOAD_COMMAND ""
-#        UPDATE_COMMAND ""
-        BUILD_IN_SOURCE True
-        INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/gfak/
-        INSTALL_COMMAND make PREFIX=${CMAKE_SOURCE_DIR}/external/gfak/ install
-        )
+if (dev)
+    # Download or update library as an external project
+    ExternalProject_Add(project_gfak
+            GIT_REPOSITORY https://github.com/edawson/gfakluge.git
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CONFIGURE_COMMAND ""
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/gfak/
+            INSTALL_COMMAND make PREFIX=${CMAKE_SOURCE_DIR}/external/gfak/ install
+            )
+else()
+    # Download or update library as an external project
+    ExternalProject_Add(project_gfak
+            GIT_REPOSITORY https://github.com/edawson/gfakluge.git
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CONFIGURE_COMMAND ""
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/gfak/
+            INSTALL_COMMAND make PREFIX=${CMAKE_SOURCE_DIR}/external/gfak/ install
+            )
+endif()
 
 # Define INSTALL_DIR as the install directory for external library
 ExternalProject_Get_Property(project_gfak INSTALL_DIR)
@@ -201,19 +218,32 @@ message(STATUS "INSTALL_DIR: ${INSTALL_DIR}")
 # Need to explicitly enable ExternalProject functionality
 include(ExternalProject)
 
-# Download or update library as an external project
-ExternalProject_Add(project_abPOA
-        GIT_REPOSITORY https://github.com/yangao07/abPOA.git
-	GIT_TAG main
-#        GIT_SUBMODULES vendor/simde
-#        DOWNLOAD_COMMAND ""
-#        UPDATE_COMMAND ""
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/abPOA/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/abPOA/lib
-        BUILD_IN_SOURCE True
-        INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/abPOA/
-        INSTALL_COMMAND make install
-        )
+if(dev)
+    # Download or update library as an external project
+    ExternalProject_Add(project_abPOA
+            GIT_REPOSITORY https://github.com/yangao07/abPOA.git
+            GIT_TAG main
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/abPOA/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/abPOA/lib
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/abPOA/
+            INSTALL_COMMAND make install
+            )
+else()
+    # Download or update library as an external project
+    ExternalProject_Add(project_abPOA
+            GIT_REPOSITORY https://github.com/yangao07/abPOA.git
+            GIT_TAG main
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/abPOA/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/abPOA/lib
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/abPOA/
+            INSTALL_COMMAND make install
+            )
+
+endif()
 
 # Define INSTALL_DIR as the install directory for external library
 ExternalProject_Get_Property(project_abPOA INSTALL_DIR)
@@ -249,18 +279,31 @@ message(STATUS "INSTALL_DIR: ${INSTALL_DIR}")
 # Need to explicitly enable ExternalProject functionality
 include(ExternalProject)
 
-# Download or update library as an external project
-ExternalProject_Add(project_bdsg
-        GIT_REPOSITORY https://github.com/vgteam/libbdsg-easy.git
-        GIT_TAG b989949811918b18de48a5e57d7f45473d8901f1
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-        CONFIGURE_COMMAND ""
-#        DOWNLOAD_COMMAND ""
-#        UPDATE_COMMAND ""
-        BUILD_IN_SOURCE True
-        INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/bdsg/
-        INSTALL_COMMAND make INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/bdsg/ install
+if(dev)
+    # Download or update library as an external project
+    ExternalProject_Add(project_bdsg
+            GIT_REPOSITORY https://github.com/vgteam/libbdsg-easy.git
+            GIT_TAG b989949811918b18de48a5e57d7f45473d8901f1
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CONFIGURE_COMMAND ""
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/bdsg/
+            INSTALL_COMMAND make INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/bdsg/ install
         )
+else()
+    # Download or update library as an external project
+    ExternalProject_Add(project_bdsg
+            GIT_REPOSITORY https://github.com/vgteam/libbdsg-easy.git
+            GIT_TAG b989949811918b18de48a5e57d7f45473d8901f1
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CONFIGURE_COMMAND ""
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/bdsg/
+            INSTALL_COMMAND make INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/bdsg/ install
+    )
+endif()
 
 # Define INSTALL_DIR as the install directory for external library
 ExternalProject_Get_Property(project_bdsg INSTALL_DIR)
@@ -313,18 +356,30 @@ message(STATUS "INSTALL_DIR: ${INSTALL_DIR}")
 # Need to explicitly enable ExternalProject functionality
 include(ExternalProject)
 
-# Download or update library as an external project
-ExternalProject_Add(project_spoa
-        GIT_REPOSITORY https://github.com/rvaser/spoa.git
-#        GIT_SUBMODULES vendor/bioparser vendor/cereal vendor/cpu_features vendor/simde
-#        DOWNLOAD_COMMAND ""
-#        UPDATE_COMMAND ""
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib
-        BUILD_IN_SOURCE True
-        INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/spoa/
-        INSTALL_COMMAND make install
-        )
+if(dev)
+    # Download or update library as an external project
+    ExternalProject_Add(project_spoa
+            GIT_REPOSITORY https://github.com/rvaser/spoa.git
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/spoa/
+            INSTALL_COMMAND make install
+    )
+
+else()
+    # Download or update library as an external project
+    ExternalProject_Add(project_spoa
+            GIT_REPOSITORY https://github.com/rvaser/spoa.git
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/spoa/
+            INSTALL_COMMAND make install
+    )
+endif()
 
 # Define INSTALL_DIR as the install directory for external library
 ExternalProject_Get_Property(project_spoa INSTALL_DIR)
@@ -400,7 +455,7 @@ find_package(ZLIB REQUIRED)
 set(TESTS
         test_AdjacencyComponent
         test_bdsg
-	test_BicliqueCover
+	    test_BicliqueCover
         test_cigar
         test_divide_handle
         test_duplicate_terminus

--- a/inc/Biclique.hpp
+++ b/inc/Biclique.hpp
@@ -7,6 +7,7 @@
 
 using handlegraph::handle_t;
 using handlegraph::edge_t;
+using handlegraph::HandleGraph;
 
 using std::vector;
 
@@ -36,6 +37,8 @@ public:
     const vector <edge_t>& operator[](size_t i) const;
 
     size_t size() const;
+
+    void print(HandleGraph& graph);
 };
 
 

--- a/inc/Cigar.hpp
+++ b/inc/Cigar.hpp
@@ -116,6 +116,9 @@ public:
             const edge_t& edge,
             uint64_t ref_start_index = 0,
             uint64_t query_start_index = 0);
+
+    bool is_exact() const;
+    static bool is_exact(vector<Cigar>& c);
 };
 
 

--- a/src/Biclique.cpp
+++ b/src/Biclique.cpp
@@ -1,5 +1,7 @@
 #include "Biclique.hpp"
 
+using std::cerr;
+
 namespace bluntifier {
 
 
@@ -30,6 +32,15 @@ vector<edge_t>& Bicliques::operator[](size_t i) {
 
 const vector<edge_t>& Bicliques::operator[](size_t i) const {
     return bicliques[i];
+}
+
+void Bicliques::print(HandleGraph& graph){
+    for (size_t i=0; i<bicliques.size(); i++){
+        cerr << "Biclique: " << i << '\n';
+        for (auto& e: bicliques[i]){
+            cerr << '\t' << graph.get_id(e.first) << "<-->" << graph.get_id(e.second) << '\n';
+        }
+    }
 }
 
 }

--- a/src/Bluntifier.cpp
+++ b/src/Bluntifier.cpp
@@ -577,20 +577,18 @@ void Bluntifier::bluntify(){
         compute_biclique_cover(i);
     }
 
+//    Uncomment for debug
+//    {
+//        ofstream test_gfa("post_biclique_cover.gfa");
+//        handle_graph_to_gfa(gfa_graph, test_gfa);
+//        test_gfa.close();
+//    }
+
     log_progress("Total biclique covers: " + to_string(bicliques.size()));
 
     // TODO: delete adjacency components vector if unneeded
 
     map_splice_sites_by_node();
-
-    for (size_t i=0; i<bicliques.size(); i++){
-        // Skip trivial bicliques
-        if (bicliques[i].empty()){
-            continue;
-        }
-
-        biclique_overlaps_are_exact(i);
-    }
 
     Duplicator super_duper(
             node_to_biclique_edge,

--- a/src/Cigar.cpp
+++ b/src/Cigar.cpp
@@ -385,6 +385,16 @@ string Alignment::create_formatted_alignment_string(
     return aligned_ref + '\n' + alignment_symbols + '\n' + aligned_query;
 }
 
+bool Alignment::is_exact() const {
+    bool exact = operations.size() == 1 and (operations[0].type() == 'M' or operations[0].type() == '=');
+    return exact;
+}
+
+bool Alignment::is_exact(vector<Cigar>& c){
+    bool exact = c.size() == 1 and (c[0].type() == 'M' or c[0].type() == '=');
+    return exact;
+}
+
 
 }
 

--- a/src/Duplicator.cpp
+++ b/src/Duplicator.cpp
@@ -33,10 +33,18 @@ map<nid_t, OverlappingNodeInfo>::iterator Duplicator::preprocess_overlapping_ove
     auto parent_handle = gfa_graph.get_handle(node_info.node_id, false);
     overlap_node_info.length = gfa_graph.get_length(parent_handle);
 
-    // Iteratively remove and document the longest overlaps, until the node is effectively a normal node
-    // Additionally, duplicate orphan segments from the parent node for the overlapping overlaps
+    bool side;
+    if (sorted_sizes_per_side[0][0] > sorted_sizes_per_side[1][0]) {
+        side = 0;
+    }
+    else {
+        side = 1;
+    }
+
+    // Iteratively remove and document the longest overlaps from alternating sides, until the node is effectively a
+    // normal node. Additionally, duplicate orphan segments from the parent node for the overlapping overlaps
     while (contains_overlapping_overlaps(gfa_graph, parent_handle, sorted_sizes_per_side)){
-        if (sorted_sizes_per_side[0][0] > sorted_sizes_per_side[1][0]){
+        if (side == 0){
             size_t s = sorted_sizes_per_side[0][0];
             string sequence = gfa_graph.get_subsequence(parent_handle, 0, s);
 
@@ -58,7 +66,7 @@ map<nid_t, OverlappingNodeInfo>::iterator Duplicator::preprocess_overlapping_ove
             sorted_sizes_per_side[0].pop_front();
             sorted_bicliques_per_side[0].pop_front();
         }
-        else{
+        else {
             size_t start = gfa_graph.get_length(parent_handle) - sorted_sizes_per_side[1][0];
             string sequence = gfa_graph.get_subsequence(parent_handle, start, sorted_sizes_per_side[1][0]);
 
@@ -80,6 +88,8 @@ map<nid_t, OverlappingNodeInfo>::iterator Duplicator::preprocess_overlapping_ove
             sorted_sizes_per_side[1].pop_front();
             sorted_bicliques_per_side[1].pop_front();
         }
+
+        side = 1 - side;
     }
 
     return result.first;


### PR DESCRIPTION
In some cases the longest-first rule causes issues when reducing overlapping overlaps because there may be multiple on the same side, and none on the other. This forces the reduction step to alternate sides, fixing #37 