### PR TITLE
Multithread

### DIFF
--- a/inc/Bluntifier.hpp
+++ b/inc/Bluntifier.hpp
@@ -24,6 +24,7 @@
 
 #include "bdsg/hash_graph.hpp"
 
+using std::atomic;
 
 using handlegraph::MutablePathDeletableHandleGraph;
 using handlegraph::as_integer;
@@ -49,8 +50,8 @@ public:
 class Bluntifier {
 private:
     /// Attributes ///
-    string gfa_path;
-    string provenance_path;
+    path gfa_path;
+    path provenance_path;
     bool verbose;
     time_t time_start;
 
@@ -80,13 +81,13 @@ private:
 
 public:
     /// Methods ///
-    Bluntifier(const string& gfa_path,
-               const string& provenance_path,
+    Bluntifier(const path& gfa_path,
+               const path& provenance_path,
                bool verbose);
     
     ~Bluntifier();
 
-    void bluntify();
+    void bluntify(size_t n_threads);
 
     void write_provenance();
 
@@ -103,11 +104,11 @@ private:
 
     void harmonize_biclique_orientations();
 
-    void align_biclique_overlaps(size_t i);
+    void align_biclique_overlaps(atomic<size_t>& index);
 
-    bool biclique_overlaps_are_exact(size_t i);
+    bool biclique_overlaps_are_exact(size_t i) const;
     
-    bool biclique_overlaps_are_short(size_t i, size_t max_len);
+    bool biclique_overlaps_are_short(size_t i, size_t max_len) const;
 
     void create_exact_subgraph(size_t i);
 

--- a/inc/Cigar.hpp
+++ b/inc/Cigar.hpp
@@ -88,7 +88,7 @@ public:
     //         query_sequence[alignment_iterator.query_index];
     //     }
     //
-    bool step_through_alignment(AlignmentIterator& iterator);
+    bool step_through_alignment(AlignmentIterator& iterator) const;
 
     // Use the ref and query sequences to find mismatches and convert all M operations to = or X
     vector<Cigar> explicitize_mismatches(
@@ -103,7 +103,7 @@ public:
             const HandleGraph& graph,
             const edge_t& edge,
             uint64_t ref_start_index = 0,
-            uint64_t query_start_index = 0);
+            uint64_t query_start_index = 0) const;
 
     // Make a cool looking alignment string
     string create_formatted_alignment_string(

--- a/inc/OverlapMap.hpp
+++ b/inc/OverlapMap.hpp
@@ -37,7 +37,7 @@ public:
     unordered_map<edge_t,Alignment>::const_iterator at(const edge_t& edge_handle) const;
     unordered_map<edge_t,Alignment>::iterator canonicalize_and_find(const edge_t& edge, const HandleGraph& graph);
     unordered_map<edge_t,Alignment>::const_iterator canonicalize_and_find(const edge_t& edge, const HandleGraph& graph) const;
-    void canonicalize_and_compute_lengths(pair<size_t,size_t>& lengths, edge_t& edge, const HandleGraph& graph);
+    void canonicalize_and_compute_lengths(pair<size_t,size_t>& lengths, const edge_t& edge, const HandleGraph& graph) const;
 };
 
 }

--- a/src/Cigar.cpp
+++ b/src/Cigar.cpp
@@ -157,7 +157,7 @@ uint64_t Alignment::compute_common_length(){
 }
 
 
-bool Alignment::step_through_alignment(AlignmentIterator& iterator){
+bool Alignment::step_through_alignment(AlignmentIterator& iterator) const{
     // Don't do anything on the first step
     if (iterator.first_step){
         iterator.first_step = false;
@@ -258,7 +258,7 @@ vector<Cigar> Alignment::explicitize_mismatches(
         const HandleGraph& graph,
         const edge_t& edge,
         uint64_t ref_start_index,
-        uint64_t query_start_index) {
+        uint64_t query_start_index) const {
 
     // TODO: rewrite this function without copying? Use insert operations instead
 

--- a/src/OverlapMap.cpp
+++ b/src/OverlapMap.cpp
@@ -109,8 +109,8 @@ unordered_map<edge_t,Alignment>::const_iterator OverlapMap::canonicalize_and_fin
 }
 
 
-void OverlapMap::canonicalize_and_compute_lengths(pair<size_t,size_t>& lengths, edge_t& edge, const HandleGraph& graph){
-    auto iter = canonicalize_and_find(edge, graph);
+void OverlapMap::canonicalize_and_compute_lengths(pair<size_t,size_t>& lengths, const edge_t& edge, const HandleGraph& graph) const{
+    const auto iter = canonicalize_and_find(edge, graph);
     iter->second.compute_lengths(lengths);
 }
 

--- a/src/executable/get_blunted.cpp
+++ b/src/executable/get_blunted.cpp
@@ -1,93 +1,49 @@
 #include "Bluntifier.hpp"
+#include "Filesystem.hpp"
+#include "CLI11.hpp"
 
 #include <iostream>
 #include <getopt.h>
 
 using bluntifier::Bluntifier;
+using ghc::filesystem::path;
 using std::ifstream;
 using std::cerr;
 using std::cout;
 using std::endl;
 
-
-void print_usage() {
-    cerr << "usage: get_blunted [options] overlap_graph.gfa > blunt_graph.gfa" << endl;
-    cerr << endl;
-    cerr << "options:" << endl;
-    cerr << " -p, --provenance FILEPATH   track origin of bluntified sequences in a table here" << endl;
-    cerr << " -V, --verbose               log progress to stderr during execution" << endl;
-    cerr << " -v, --version               print the version to stdout and exit" << endl;
-    cerr << " -h, --help                  print this help message to stderr and exit" << endl;
-}
-
-void print_version() {
-    cout << "get_blunted version 0.0.2" << endl;
-}
-
 int main(int argc, char **argv){
-    
-    string provenance_path;
+
+    path gfa_path;
+    path provenance_path;
+    size_t n_threads = 1;
     bool verbose = false;
-    
-    int c;
-    while (true){
-        static struct option long_options[] =
-        {
-            {"provenance", required_argument, 0, 'p'},
-            {"verbose", no_argument, 0, 'V'},
-            {"version", no_argument, 0, 'v'},
-            {"help", no_argument, 0, 'h'},
-            {0,0,0,0}
-        };
-        
-        int option_index = 0;
-        c = getopt_long (argc, argv, "p:Vvh",
-                         long_options, &option_index);
-        if (c == -1){
-            break;
-        }
-        
-        switch(c){
-            case 'p':
-                provenance_path = optarg;
-                break;
-            case 'V':
-                verbose = true;
-                break;
-            case 'v':
-                print_version();
-                return 0;
-            case 'h':
-            case '?':
-                print_usage();
-                return 0;
-            default:
-                print_usage();
-                return 1;
-        }
-    }
-    
-    if (optind >= argc) {
-        // no positional arguments
-        cerr << "ERROR: overlap GFA file is required" << endl;
-        print_usage();
-        return 1;
-    }
-    
-    string gfa_path = argv[optind];
-    ++optind;
-    
-    if (optind < argc) {
-        // arguments are included past the positional argument
-        
-        cerr << "ERROR: unused argument(s):" << endl;
-        while (optind < argc) {
-            cerr << "\t" << argv[optind] << endl;
-            ++optind;
-        }
-        return 1;
-    }
-    
+
+    CLI::App app{"GetBlunted v0.0.3"};
+
+    app.add_option(
+            "-i,--input_gfa",
+            gfa_path,
+            "Path to GFA containing overlaps")
+            ->required();
+
+    app.add_option(
+            "-p,--provenance",
+            provenance_path,
+            "Optionally generate a table containing info about the origin of each output node");
+
+    app.add_option(
+            "-t,--threads",
+            n_threads,
+            "Number of threads to use (maximum)");
+
+    app.add_flag(
+            "-V,--verbose",
+            verbose,
+            "Print a timed log showing progress/steps");
+
+    CLI11_PARSE(app, argc, argv);
+
     // test input for openability
     if (!ifstream(gfa_path)) {
         cerr << "ERROR: could not open input GFA " << gfa_path << endl;
@@ -103,7 +59,7 @@ int main(int argc, char **argv){
     }
     
     Bluntifier bluntifier(gfa_path, provenance_path, verbose);
-    bluntifier.bluntify();
+    bluntifier.bluntify(n_threads);
 
     return 0;
 }


### PR DESCRIPTION
I went ahead and implemented multithreading for the alignment step.

For example:

Running single threaded (1min)
```
ryan@computron:~/code/GetBlunted/build$ ./get_blunted -p prov.txt -V -i /home/ryan/data/test_getblunted/issue_37/new_example/comp_both.gfa > /home/ryan/data/test_getblunted/issue_37/new_example/comp_both.blunted_1t.gfa
[get_blunted] Executing command: ./get_blunted -p prov.txt -V -i /home/ryan/data/test_getblunted/issue_37/new_example/comp_both.gfa
[get_blunted : 0.0 s elapsed] Reading GFA...
[get_blunted : 0.0 s elapsed] Computing adjacency components...
[get_blunted : 0.0 s elapsed] Total adjacency components: 350
[get_blunted : 0.0 s elapsed] Computing biclique covers...
[get_blunted : 0.0 s elapsed] Total biclique covers: 215
[get_blunted : 0.0 s elapsed] Duplicating node termini...
[get_blunted : 0.0 s elapsed] Harmonizing biclique edge orientations...
[get_blunted : 0.0 s elapsed] Aligning overlaps...
[get_blunted : 1.0 m elapsed] Splicing 215 subgraphs...
[get_blunted : 1.0 m elapsed] Splicing overlapping overlap nodes...
[get_blunted : 1.0 m elapsed] Inferring provenance...
[get_blunted : 1.0 m elapsed] Writing provenance to file: prov.txt
[get_blunted : 1.0 m elapsed] Destroying duplicated nodes...
[get_blunted : 1.0 m elapsed] Writing bluntified GFA to file to STDOUT
```

Running with 8 threads (13s)
```
ryan@computron:~/code/GetBlunted/build$ ./get_blunted -p prov.txt -V -i /home/ryan/data/test_getblunted/issue_37/new_example/comp_both.gfa -t 8 > /home/ryan/data/test_getblunted/issue_37/new_example/comp_both.blunted_8t.gfa
[get_blunted] Executing command: ./get_blunted -p prov.txt -V -i /home/ryan/data/test_getblunted/issue_37/new_example/comp_both.gfa -t 8
[get_blunted : 0.0 s elapsed] Reading GFA...
[get_blunted : 0.0 s elapsed] Computing adjacency components...
[get_blunted : 0.0 s elapsed] Total adjacency components: 350
[get_blunted : 0.0 s elapsed] Computing biclique covers...
[get_blunted : 0.0 s elapsed] Total biclique covers: 215
[get_blunted : 0.0 s elapsed] Duplicating node termini...
[get_blunted : 0.0 s elapsed] Harmonizing biclique edge orientations...
[get_blunted : 0.0 s elapsed] Aligning overlaps...
[get_blunted : 13.0 s elapsed] Splicing 215 subgraphs...
[get_blunted : 13.0 s elapsed] Splicing overlapping overlap nodes...
[get_blunted : 13.0 s elapsed] Inferring provenance...
[get_blunted : 13.0 s elapsed] Writing provenance to file: prov.txt
[get_blunted : 13.0 s elapsed] Destroying duplicated nodes...
[get_blunted : 13.0 s elapsed] Writing bluntified GFA to file to STDOUT
```

Also modernized the CLI parser, which incidentally means the `-i` flag is now required for the input path of the GFA.